### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Make native Linux Garry's Mod playable and fast.
 
 ### Installation and Usage
-`wget -q https://raw.githubusercontent.com/ret-0/gmod-linux-patcher/master/gmod-linux-patcher.sh && sh gmod-linux-patcher.sh`
+`wget -q https://raw.githubusercontent.com/ret-0/gmod-linux-patcher/master/gmod-linux-patcher.sh && bash gmod-linux-patcher.sh`
 
 ### Manual Patching
 1. Right-click on Garry's Mod in Steam -> Properties -> Betas -> Select 'x86_64 - Chromium + 64-bit binaries'.


### PR DESCRIPTION
running 'sh gmod-linux-patcher.sh' forces it to use /bin/sh which is often dash on linux and sh doesn't support bash-specific stuff like 'read -p' and process substitution